### PR TITLE
Ajustar puertos del frontend de 5183 a 3000 y configuración de CORS para alinear los cambios de puerto

### DIFF
--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -8,8 +8,8 @@ const app = express();
 
 app.use(cors({
   origin: [
-    'http://localhost:5173',
-    'http://127.0.0.1:5173'
+    'http://localhost:3000',
+    'http://127.0.0.1:3000'
   ],
   credentials: true
 }));

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -8,5 +8,6 @@ export default defineConfig({
     proxy: {
       '/api': 'http://localhost:4000',
     },
+    port: 3000,  // Cambiar el puerto a 3000
   },
 })


### PR DESCRIPTION
Se modificó el archivo `vite.config.ts` para establecer el puerto del servidor de desarrollo en `3000` en lugar del predeterminado `5173`. Esto mejora la compatibilidad con backends que corren en puertos bajos (ej. 4000) y evita conflictos con otras aplicaciones locales.

Y se actualizó el middleware CORS en app.js del backend para aceptar http://localhost:3000.
Ambos cambios están relacionados para asegurar que el frontend y backend puedan comunicarse correctamente durante el desarrollo.

Se modifica la configuración del frontend para usar el puerto 3000, tal como indica la documentación (README.md).

Este cambio no afecta el entorno productivo ni el comportamiento del proxy configurado para `/api`.